### PR TITLE
Possible fix for flaky test

### DIFF
--- a/src/CrossCutting/Configuration.cs
+++ b/src/CrossCutting/Configuration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Microsoft.Extensions.Configuration;
 
 namespace CrossCutting
@@ -7,12 +8,13 @@ namespace CrossCutting
     {
         public static IConfigurationRoot BuildConfiguration()
         {
-            var basePath = new Uri(AppDomain.CurrentDomain.BaseDirectory).AbsolutePath;
-            var sourcePath = basePath.Substring(0, basePath.IndexOf("/bin"));
-            var projectRoot = basePath.Substring(0, sourcePath.LastIndexOf('/'));
+            var separator = Path.DirectorySeparatorChar;
+            var basePath = AppDomain.CurrentDomain.BaseDirectory;
+            var sourcePath = basePath.Substring(0, basePath.IndexOf(separator + "bin"));
+            var projectRoot = basePath.Substring(0, sourcePath.LastIndexOf(separator));
             return new ConfigurationBuilder()
                 .SetBasePath(projectRoot)
-                .AddJsonFile("Properties/appsettings.json", optional: false)
+                .AddJsonFile("Properties" + separator + "appsettings.json", optional: false)
                 .Build();
         }
     }

--- a/src/Testing/MqttTests.cs
+++ b/src/Testing/MqttTests.cs
@@ -101,7 +101,7 @@ namespace Testing
         [Test]
         public async Task ReceiveAllC2DMessagesWhileDisconnected()
         {
-            //Arrange
+            // Arrange
             var device = new Device(iotHubDeviceConnectionString);
             var sender = new Sender(iotHubConnectionString, deviceId);
             var payloads = new ConcurrentBag<string>();
@@ -110,7 +110,8 @@ namespace Testing
                 payloads.Add(e.ApplicationMessage.ConvertPayloadToString());
             };
 
-            //Send first payload when device is connected 
+            // Act & Assert
+            // Send first payload when device is connected 
             var firstPayload = Guid.NewGuid().ToString();
             await device.ConnectDevice();
             await device.SubscribeToEventAsync(applicationMessageReceived);
@@ -120,7 +121,7 @@ namespace Testing
 
             await device.DisconnectDevice();
 
-            //Send second payload when device is disconnected 
+            // Send second payload when device is disconnected 
             var secondPayload = Guid.NewGuid().ToString();
             await sender.SendCloudToDeviceMessageAsync(secondPayload);
             await device.ConnectDevice();

--- a/src/Testing/MqttTests.cs
+++ b/src/Testing/MqttTests.cs
@@ -101,31 +101,31 @@ namespace Testing
         [Test]
         public async Task ReceiveAllC2DMessagesWhileDisconnected()
         {
-            // Arrange
+            //Arrange
             var device = new Device(iotHubDeviceConnectionString);
             var sender = new Sender(iotHubConnectionString, deviceId);
-            var firstPayload = Guid.NewGuid().ToString();
-            var secondPayload = Guid.NewGuid().ToString();
             var payloads = new ConcurrentBag<string>();
             Action<MqttApplicationMessageReceivedEventArgs> applicationMessageReceived = (MqttApplicationMessageReceivedEventArgs e) =>
             {
                 payloads.Add(e.ApplicationMessage.ConvertPayloadToString());
             };
 
-            // Act
+            //Send first payload when device is connected 
+            var firstPayload = Guid.NewGuid().ToString();
             await device.ConnectDevice();
             await device.SubscribeToEventAsync(applicationMessageReceived);
             await sender.SendCloudToDeviceMessageAsync(firstPayload);
+
             Assert.IsTrue(RetryUntilSuccessOrTimeout(() => payloads.FirstOrDefault(x => x == firstPayload) != null, TimeSpan.FromSeconds(10)));
 
             await device.DisconnectDevice();
-            await sender.SendCloudToDeviceMessageAsync(secondPayload);
 
-            device = new Device(iotHubDeviceConnectionString);
+            //Send second payload when device is disconnected 
+            var secondPayload = Guid.NewGuid().ToString();
+            await sender.SendCloudToDeviceMessageAsync(secondPayload);
             await device.ConnectDevice();
             await device.SubscribeToEventAsync(applicationMessageReceived);
 
-            // Assert
             Assert.IsTrue(RetryUntilSuccessOrTimeout(() => payloads.FirstOrDefault(x => x == secondPayload) != null, TimeSpan.FromSeconds(10)));
         }
 


### PR DESCRIPTION
The purpose of this PR is to propose a fix for the flaky test. Closes #20.

Apart from rearranging the test flow to increase readability, the main change is that I removed the line marked in this image.
![tempsnip](https://user-images.githubusercontent.com/69301842/99527496-2c9ca600-299d-11eb-8252-b5695f413196.png)

Since making this change, I ran the test more than 50 times both in VS and VS Code and had no more failures.
However, I do not exactly understand what was the issue before. I assume that some sort of this disconnection occurs and the messages are lost. I tried to listen for a WILL message which might have proven an ungraceful disconnect, but there weren't any sent.

FINAL CONCLUSION
Creating another instance of the Device class with the same connection string and storing it in the same object leads to creating another instance of the MqttClient object which in some of the test runs appears to result in not receiving the message sent while the client is disconnected. 